### PR TITLE
enable folding for python language samples

### DIFF
--- a/browser-esm-parcel/index.js
+++ b/browser-esm-parcel/index.js
@@ -15,7 +15,7 @@ import 'monaco-editor/esm/vs/editor/browser/controller/coreCommands.js';
 // import 'monaco-editor/esm/vs/editor/contrib/cursorUndo/cursorUndo.js';
 // import 'monaco-editor/esm/vs/editor/contrib/dnd/dnd.js';
 import 'monaco-editor/esm/vs/editor/contrib/find/findController.js';
-// import 'monaco-editor/esm/vs/editor/contrib/folding/folding.js';
+import 'monaco-editor/esm/vs/editor/contrib/folding/folding.js';
 // import 'monaco-editor/esm/vs/editor/contrib/format/formatActions.js';
 // import 'monaco-editor/esm/vs/editor/contrib/goToDeclaration/goToDeclarationCommands.js';
 // import 'monaco-editor/esm/vs/editor/contrib/goToDeclaration/goToDeclarationMouse.js';
@@ -123,5 +123,6 @@ monaco.editor.create(document.getElementById('container'), {
 		'		eat(9.25)',
 		'		return "Yum yum"',
 	].join('\n'),
-	language: 'python'
+	language: 'python',
+	folding: true
 });

--- a/browser-esm-webpack-small/index.js
+++ b/browser-esm-webpack-small/index.js
@@ -15,7 +15,7 @@ import 'monaco-editor/esm/vs/editor/browser/controller/coreCommands.js';
 // import 'monaco-editor/esm/vs/editor/contrib/cursorUndo/cursorUndo.js';
 // import 'monaco-editor/esm/vs/editor/contrib/dnd/dnd.js';
 import 'monaco-editor/esm/vs/editor/contrib/find/findController.js';
-// import 'monaco-editor/esm/vs/editor/contrib/folding/folding.js';
+import 'monaco-editor/esm/vs/editor/contrib/folding/folding.js';
 // import 'monaco-editor/esm/vs/editor/contrib/format/formatActions.js';
 // import 'monaco-editor/esm/vs/editor/contrib/goToDeclaration/goToDeclarationCommands.js';
 // import 'monaco-editor/esm/vs/editor/contrib/goToDeclaration/goToDeclarationMouse.js';
@@ -123,5 +123,6 @@ monaco.editor.create(document.getElementById('container'), {
 		'		eat(9.25)',
 		'		return "Yum yum"',
 	].join('\n'),
-	language: 'python'
+	language: 'python',
+	folding: true
 });


### PR DESCRIPTION
This PR is only to enable folding for a demo.
However, there seems to be a bug where the folding icons <kbd>+</kbd> / <kbd>-</kbd> do not appear in the gutter. Not sure if the bug in in the sample or in the main repo.

![folding2](https://user-images.githubusercontent.com/11507384/38274541-ee5e260a-3743-11e8-8a2c-4ff0ef392c37.gif)
