### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm install && npm run simpleserver"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+[![Run on Repl.it](https://repl.it/badge/github/microsoft/monaco-editor-samples)](https://repl.it/github/microsoft/monaco-editor-samples)
 # Monaco Editor Samples
 
 Standalone HTML samples showing how to integrate the Monaco Editor.


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@PDanielY/monaco-editor-samples).